### PR TITLE
rule out already-uploaded dists earlier

### DIFF
--- a/bin/cpan-dist-counts
+++ b/bin/cpan-dist-counts
@@ -35,12 +35,12 @@ $USER = uc($USER) if defined($USER);
 RELEASE:
 while (my $release = $iterator->next_release) {
     my $distname = $release->distinfo->dist;
-    next if $USER && $release->distinfo->cpanid ne $USER;
-    next if $DIST_PREFIX && $distname !~ qr/^\Q$DIST_PREFIX\E/;
     if ($NEWCPANISMS_ONLY) {
         next RELEASE if $seen{ $distname };
         $seen{$distname} = 1;
     }
+    next if $USER && $release->distinfo->cpanid ne $USER;
+    next if $DIST_PREFIX && $distname !~ qr/^\Q$DIST_PREFIX\E/;
     my @ts    = gmtime($release->timestamp);
     my $year  = $ts[5] + 1900;
     next if defined($TARGET_YEAR) && $year != $TARGET_YEAR;


### PR DESCRIPTION
If --neo is meant to mean "only the first time a given distname is
uploaded" -- and I propose that it is -- then we need to count each
upload for a distname before ruling dists out based on author.

Without this patch, --neo with --user finds the _user's_ first upload
of a given dist.  This can certainly be useful, but I don't think it's
the intent of --neo.
